### PR TITLE
[FIX] CENABLER-2680 - Updated version auth mf to 0.0.13

### DIFF
--- a/mf-dev/console/console-import-map.json
+++ b/mf-dev/console/console-import-map.json
@@ -8,7 +8,7 @@
     "@digital-enabler/demf-dme-event-handler": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dme-event-handler@0.0.2/app.js",
     "@digital-enabler/sidebar": "https://cdn.jsdelivr.net/npm/@digital-enabler/sidebar@0.0.24/app.js",
     "@digital-enabler/footer": "https://cdn.jsdelivr.net/npm/@digital-enabler/footer@0.0.9/app.js",
-    "@digital-enabler/auth": "https://cdn.jsdelivr.net/npm/@digital-enabler/auth@0.0.12/app.js",
+    "@digital-enabler/auth": "https://cdn.jsdelivr.net/npm/@digital-enabler/auth@0.0.13/app.js",
     "@digital-enabler/demf-console-home": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-console-home@0.0.17/app.js",
     "@digital-enabler/demf-console-all-services": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-console-all-services@0.0.12/app.js",
     "@digital-enabler/demf-console-contexts": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-console-contexts@0.0.3/app.js",

--- a/mf-dev/console/console-sidebar-config.json
+++ b/mf-dev/console/console-sidebar-config.json
@@ -35,10 +35,11 @@
     "uri": ""
   },
   "keycloak": {
-    "url": "",
-    "clientId": "",
-    "enabled": false
-  },
+    "url": "https://idm.dev-digital-enabler.eng.it/auth",
+    "clientId": "console-app",
+    "enabled": "enabled",
+    "redirect": "https://console.dev.dev-digital-enabler.eng.it/home"
+},
   "logo": "/DigitalEnabler.svg",
   "miniLogo": "/de-mini.svg",
   "showServicesMenu": false


### PR DESCRIPTION
Updated mf auth version from 0.0.12 to 0.0.13 and added necessary properties to console-sidebar.config.json in order for redirects to work properly 