### PR TITLE
[Build] updates versions and flow-editor config

### DIFF
--- a/mf-dev/dme/dme-flow-editor-config.json
+++ b/mf-dev/dme/dme-flow-editor-config.json
@@ -1,4 +1,5 @@
 {
     "mf": "Flow Editor",
-    "api": "https://dme-api.dev-digital-enabler.eng.it/api"
+    "api": "https://dme-api.dev-digital-enabler.eng.it/api",
+    "triggerProxyUrlLayout": "[protocol_current_url]//dme-proxy.[Tenant][domain_current_url]/mashups/[id_mashup]"
 }

--- a/mf-dev/dme/dme-import-map.json
+++ b/mf-dev/dme/dme-import-map.json
@@ -16,7 +16,7 @@
     "@digital-enabler/dme-datasources-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasources-list@0.0.14/app.js",
     "@digital-enabler/dme-datasource-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasource-details@0.0.11/app.js",
     "@digital-enabler/dme-flows-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flows-list@0.0.6/app.js",
-    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@0.0.12/app.js",
+    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@0.0.13/app.js",
     "@digital-enabler/dme-gui": "https://mashupsui.dev.dev-digital-enabler.eng.it/demf-dme-gui.js"
   }
 }


### PR DESCRIPTION
Update dme-import-map.json dme-flow-editor to 0.0.13;
Adds a new key with a URL pattern that allows the users to invoke the mashup through simple HTTP requests;
