### PR TITLE
[BUILD] Remove assets api

### DIFF
--- a/mf-dev/rm/rm-import-map.json
+++ b/mf-dev/rm/rm-import-map.json
@@ -10,7 +10,7 @@
     "@digital-enabler/demf-dme-event-handler": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dme-event-handler@1.0.0/app.js",
     "@digital-enabler/demf-rules-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rules-list@0.0.5/app.js",
     "@digital-enabler/demf-rule-editor-control-panel": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-control-panel@0.0.2/app.js",
-    "@digital-enabler/demf-rule-editor-assets": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-assets@0.0.2/app.js",
+    "@digital-enabler/demf-rule-editor-assets": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-assets@0.0.3/app.js",
     "@digital-enabler/demf-rule-editor-conditions": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-conditions@0.0.2/app.js",
     "@digital-enabler/demf-rule-editor-actions": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-actions@0.0.1/app.js",
     "@digital-enabler/rm-gui": "https://rules.dev.dev-digital-enabler.eng.it/demf-rm-gui.js"

--- a/mf-dev/rm/rm-rule-editor-config.json
+++ b/mf-dev/rm/rm-rule-editor-config.json
@@ -1,6 +1,5 @@
 {
   "mf": "Rule Editor",
   "api": "https://derm-api.dev-digital-enabler.eng.it/api/v1",
-  "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
-  "apiAssetsUrl": "https://f87d8c7c-3048-465e-a9be-8131e2a875d8.mock.pstmn.io/api/v1"
+  "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }


### PR DESCRIPTION
Remove un-used asset-api url from editor configs;
Updates RM editor-assets to version 0.0.3