### PR TITLE
[FIX] Downgraded version of rm-conditions to 0.0.6

### DIFF
--- a/mf-dev/rm/rm-import-map.json
+++ b/mf-dev/rm/rm-import-map.json
@@ -11,7 +11,7 @@
     "@digital-enabler/demf-rules-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rules-list@0.0.8/app.js",
     "@digital-enabler/demf-rule-editor-control-panel": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-control-panel@0.0.3/app.js",
     "@digital-enabler/demf-rule-editor-assets": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-assets@0.0.6/app.js",
-    "@digital-enabler/demf-rule-editor-conditions": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-conditions@0.0.7/app.js",
+    "@digital-enabler/demf-rule-editor-conditions": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-conditions@0.0.6/app.js",
     "@digital-enabler/demf-rule-editor-actions": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-actions@0.0.3/app.js",
     "@digital-enabler/demf-rule-editor-summary": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-rule-editor-summary@0.0.3/app.js",
     "@digital-enabler/rm-gui": "https://rules.dev.dev-digital-enabler.eng.it/demf-rm-gui.js"


### PR DESCRIPTION
Downgraded the version of rule-manager-conditions micro front end due to a bug appearing "POST method not allowed" after selecting assets in the first step and clicking on the continue button.