### PR TITLE
[FIX] Changed API Url for the rulemanager

### DIFF
--- a/mf-dev/rm/rm-auth-config.json
+++ b/mf-dev/rm/rm-auth-config.json
@@ -1,6 +1,6 @@
 {
   "mf": "Auth",
-  "api": "https://derm-api.dev-digital-enabler.eng.it/api/v1",
+  "api": "https://rm-middleware-api.dev-digital-enabler.eng.it/api/v1",
   "keycloak": {
     "url": "https://idm.dev-digital-enabler.eng.it/auth",
     "clientId": "rule-app",

--- a/mf-dev/rm/rm-event-handler-config.json
+++ b/mf-dev/rm/rm-event-handler-config.json
@@ -1,4 +1,4 @@
 {
   "mf": "Event Handler",
-  "api": "https://derm-api.dev-digital-enabler.eng.it/api/v1"
+  "api": "https://rm-middleware-api.dev-digital-enabler.eng.it/api/v1"
 }

--- a/mf-dev/rm/rm-rule-editor-config.json
+++ b/mf-dev/rm/rm-rule-editor-config.json
@@ -1,5 +1,5 @@
 {
   "mf": "Rule Editor",
-  "api": "https://derm-api.dev-digital-enabler.eng.it/api/v1",
+  "api": "https://rm-middleware-api.dev-digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-dev/rm/rm-rules-list-config.json
+++ b/mf-dev/rm/rm-rules-list-config.json
@@ -1,6 +1,6 @@
 {
   "mf": "Rules List",
-  "api": "https://derm-api.dev-digital-enabler.eng.it/api/v1",
+  "api": "https://rm-middleware-api.dev-digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "apiAssetsUrl": "https://f87d8c7c-3048-465e-a9be-8131e2a875d8.mock.pstmn.io/api/v1"
 }

--- a/mf-dev/rm/rm-sidebar-config.json
+++ b/mf-dev/rm/rm-sidebar-config.json
@@ -1,6 +1,6 @@
 {
   "mf": "Sidebar",
-  "api": "https://derm-api.dev-digital-enabler.eng.it/api/v1",
+  "api": "https://rm-middleware-api.dev-digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "jsonTools": "https://raw.githubusercontent.com/digital-enabler/UI-Configs/main/mf-dev/common/services.json",
   "links": [


### PR DESCRIPTION
Changed API Url for the rulemanager

new api url: https://rm-middleware-api.dev-digital-enabler.eng.it/api/v1