### PR TITLE
[BUILD] Update dme-flow-editor to version 2.1.2 in import maps

### DIFF
--- a/mf-avant/dme/dme-import-map.json
+++ b/mf-avant/dme/dme-import-map.json
@@ -16,7 +16,7 @@
     "@digital-enabler/dme-datasources-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasources-list@2.1.1/app.js",
     "@digital-enabler/dme-datasource-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasource-details@2.0.5/app.js",
     "@digital-enabler/dme-flows-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flows-list@2.2.0/app.js",
-    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@2.0.2/app.js",
+    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@2.1.2/app.js",
     "@digital-enabler/demf-custom-operators": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-custom-operators@1.1.1/app.js",
     "@digital-enabler/demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-custom-operator-details@1.0.2/app.js",
     "@digital-enabler/dme-gui": "https://mashups.avant.digital-enabler.eng.it/demf-dme-gui.js"

--- a/mf-citrace/dme/dme-import-map.json
+++ b/mf-citrace/dme/dme-import-map.json
@@ -16,7 +16,7 @@
     "@digital-enabler/dme-datasources-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasources-list@2.1.1/app.js",
     "@digital-enabler/dme-datasource-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasource-details@2.0.5/app.js",
     "@digital-enabler/dme-flows-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flows-list@2.2.0/app.js",
-    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@2.0.2/app.js",
+    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@2.1.2/app.js",
     "@digital-enabler/demf-custom-operators": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-custom-operators@1.1.1/app.js",
     "@digital-enabler/demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-custom-operator-details@1.0.2/app.js",
     "@digital-enabler/dme-gui": "https://mashups.citrace.digital-enabler.eng.it/demf-dme-gui.js"

--- a/mf-regions4climate/dme/dme-import-map.json
+++ b/mf-regions4climate/dme/dme-import-map.json
@@ -16,7 +16,7 @@
     "@digital-enabler/dme-datasources-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasources-list@2.1.1/app.js",
     "@digital-enabler/dme-datasource-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasource-details@2.0.5/app.js",
     "@digital-enabler/dme-flows-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flows-list@2.2.0/app.js",
-    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@2.0.2/app.js",
+    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@2.1.2/app.js",
     "@digital-enabler/demf-custom-operators": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-custom-operators@1.1.1/app.js",
     "@digital-enabler/demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-custom-operator-details@1.0.2/app.js",
     "@digital-enabler/dme-gui": "https://mashups.regions4climate.digital-enabler.eng.it/demf-dme-gui.js"

--- a/temporaryConfigs/mf-dev/dme/dme-import-map.json
+++ b/temporaryConfigs/mf-dev/dme/dme-import-map.json
@@ -16,7 +16,7 @@
     "@digital-enabler/dme-datasources-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasources-list@2.1.1/app.js",
     "@digital-enabler/dme-datasource-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-datasource-details@2.0.5/app.js",
     "@digital-enabler/dme-flows-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flows-list@2.2.0/app.js",
-    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@2.0.2/app.js",
+    "@digital-enabler/dme-flow-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/dme-flow-editor@2.1.2/app.js",
     "@digital-enabler/demf-custom-operators": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-custom-operators@1.1.1/app.js",
     "@digital-enabler/demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-custom-operator-details@1.0.2/app.js",
     "@digital-enabler/dme-gui": "https://mashupsuiv3.dev.dev-digital-enabler.eng.it/demf-dme-gui.js"


### PR DESCRIPTION
Bump @digital-enabler/dme-flow-editor from 2.0.2 to 2.1.2 across all dme-import-map.json files to ensure all environments use the latest version.