### PR TITLE
Update Data Discovery configs: API URLs & options

### DIFF
--- a/temp/mf-avant/dd/dd-data-discovery-config.json
+++ b/temp/mf-avant/dd/dd-data-discovery-config.json
@@ -1,7 +1,7 @@
 {
   "name": "Data Discovery",
   "mf": "demf-data-discovery",
-  "api": "//localhost:8083/api/v3",
+  "api": "https://discovery-api.avant.digital-enabler.eng.it/api/v3",
   "standaloneMode": true,
   "fileFormats": {
     "CSV": { "icon": "mdi-file-delimited", "color": "green" },

--- a/temp/mf-avant/dme/dme-data-discovery-config.json
+++ b/temp/mf-avant/dme/dme-data-discovery-config.json
@@ -1,14 +1,16 @@
 {
-    "name": "Data Discovery",
-    "mf": "demf-data-discovery",
-    "api": "//localhost:8083/api/v3",
-    "fileFormats": {
-        "CSV":  { "icon": "mdi-file-delimited", "color": "green" },
-        "JSON": { "icon": "mdi-code-json", "color": "blue" },
-        "XML":  { "icon": "mdi-file-code", "color": "deep-orange" },
-        "PDF":  { "icon": "mdi-file-pdf-box", "color": "red" },
-        "XLSX": { "icon": "mdi-file-excel", "color": "teal" },
-        "XLS":  { "icon": "mdi-file-excel", "color": "teal" },
-        "ZIP":  { "icon": "mdi-folder-zip", "color": "amber" }
-      }
+  "name": "Data Discovery",
+  "mf": "demf-data-discovery",
+  "api": "https://dme-api.avant.digital-enabler.eng.it/api/v3",
+  "standaloneMode": false,
+  "fileFormats": {
+    "CSV": { "icon": "mdi-file-delimited", "color": "green" },
+    "JSON": { "icon": "mdi-code-json", "color": "blue" },
+    "XML": { "icon": "mdi-file-code", "color": "deep-orange" },
+    "PDF": { "icon": "mdi-file-pdf-box", "color": "red" },
+    "XLSX": { "icon": "mdi-file-excel", "color": "teal" },
+    "XLS": { "icon": "mdi-file-excel", "color": "teal" },
+    "ZIP": { "icon": "mdi-folder-zip", "color": "amber" }
+  },
+  "searchTimeout": 120000
 }


### PR DESCRIPTION
Replace local //localhost API endpoints with environment-specific URLs for Data Discovery (dd and dme). For the DME config, set standaloneMode to false, add a searchTimeout (120000 ms), and normalize JSON formatting/indentation. These changes point the apps to real API hosts and adjust behavior for the DME environment.