### PR TITLE
Update DTM configs and import maps

### DIFF
--- a/mf-avant/config.json
+++ b/mf-avant/config.json
@@ -58,14 +58,14 @@
       "auth": "/dtm/dtm-auth-config.json",
       "eventHandler": "/dtm/dtm-event-handler-config.json",
       "sidebar": "/dtm/dtm-sidebar-config.json",
-      "digitalTwinCommon": "/dtm/dtm-common-config.json",
-      "digitalTwinModelsList": "/dtm/dtm-models-list-config.json",
-      "digitalTwinRelationsEditor": "/dtm/dtm-relations-editor-config.json",
-      "digitalTwinDataDefinition": "/dtm/dtm-data-definition-config.json",
-      "digitalTwinModelConversion": "/dtm/dtm-model-conversion-config.json",
-      "digitalTwinModelSummary": "/dtm/dtm-model-summary-config.json",
-      "digitalTwinEntitiesList": "/dtm/dtm-entities-list-config.json",
-      "digitalTwinEntity": "/dtm/dtm-entity-config.json"
+      "dtmEditor": "/dtm/dtm-editor-config.json",
+      "dtmModelsList": "/dtm/dtm-models-list-config.json",
+      "dtmEditorDefinitions": "/dtm/dtm-editor-definition-config.json",
+      "dtmEditorDataBinding": "/dtm/dtm-editor-data-binding-config.json",
+      "dtmEditorConversion": "/dtm/dtm-editor-conversion-config.json",
+      "dtmEditorSummary": "/dtm/dtm-editor-summary-config.json",
+      "dtmEntitiesList": "/dtm/dtm-entities-list-config.json",
+      "dtmEntity": "/dtm/dtm-entity-config.json"
     }
   }
 }

--- a/mf-avant/dtm/dtm-auth-config.json
+++ b/mf-avant/dtm/dtm-auth-config.json
@@ -1,9 +1,5 @@
 {
-  "mf": "Auth",
-  "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
-  "keycloak": {
-    "url": "https://idm.digital-enabler.eng.it/auth",
-    "clientId": "rule-app",
-    "enabled": false
-  }
+  "name": "Auth",
+  "mf": "demf-auth",
+  "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1"
 }

--- a/mf-avant/dtm/dtm-editor-config.json
+++ b/mf-avant/dtm/dtm-editor-config.json
@@ -1,5 +1,8 @@
 {
-  "mf": "Digital Twin Common",
+  "name": "DTM Editor",
+  "mf": "demf-dtm-editor",
+  "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
+  "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "domains": [
     {
       "name": "Urban",

--- a/mf-avant/dtm/dtm-editor-conversion-config.json
+++ b/mf-avant/dtm/dtm-editor-conversion-config.json
@@ -1,5 +1,6 @@
 {
-  "mf": "Digital Twin Model Conversion",
+  "name": "DTM Editor Conversion",
+  "mf": "demf-dtm-editor-conversion",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-avant/dtm/dtm-editor-data-binding-config.json
+++ b/mf-avant/dtm/dtm-editor-data-binding-config.json
@@ -1,5 +1,6 @@
 {
-  "mf": "Digital Twin Data Definition",
+  "name": "DTM Editor Data Binding",
+  "mf": "demf-dtm-editor-data-binding",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-avant/dtm/dtm-editor-definition-config.json
+++ b/mf-avant/dtm/dtm-editor-definition-config.json
@@ -1,5 +1,6 @@
 {
-  "mf": "Digital Twin Model Summary",
+  "name": "DTM Editor Definition",
+  "mf": "demf-dtm-editor-definition",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-avant/dtm/dtm-editor-summary-config.json
+++ b/mf-avant/dtm/dtm-editor-summary-config.json
@@ -1,5 +1,6 @@
 {
-  "mf": "Digital Twin Relations Editor",
+  "name": "DTM Editor Summary",
+  "mf": "demf-dtm-editor-summary",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-avant/dtm/dtm-entities-list-config.json
+++ b/mf-avant/dtm/dtm-entities-list-config.json
@@ -1,5 +1,6 @@
 {
-  "mf": "Digital Twin Entities List",
+  "name": "DTM Entities List",
+  "mf": "demf-dtm-entities-list",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "apiAssetsUrl": "https://f87d8c7c-3048-465e-a9be-8131e2a875d8.mock.pstmn.io/api/v1"

--- a/mf-avant/dtm/dtm-entity-config.json
+++ b/mf-avant/dtm/dtm-entity-config.json
@@ -1,5 +1,6 @@
 {
-  "mf": "Digital Twin Entity",
+  "name": "DTM Entity",
+  "mf": "demf-dtm-entity",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "apiAssetsUrl": "https://f87d8c7c-3048-465e-a9be-8131e2a875d8.mock.pstmn.io/api/v1"

--- a/mf-avant/dtm/dtm-event-handler-config.json
+++ b/mf-avant/dtm/dtm-event-handler-config.json
@@ -1,4 +1,5 @@
 {
-  "mf": "Event Handler",
+  "name": "Event Handler",
+  "mf": "demf-event-handler",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1"
 }

--- a/mf-avant/dtm/dtm-import-map.json
+++ b/mf-avant/dtm/dtm-import-map.json
@@ -1,20 +1,20 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.0/lib/es2015/system/single-spa.min.js",
-    "vue": "https://cdn.jsdelivr.net/npm/vue@3.5/dist/vue.global.min.js",
-    "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@4.2.5/dist/vue-router.global.min.js",
-    "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.8/dist/vuetify.min.js",
-    "@digital-enabler/auth": "https://cdn.jsdelivr.net/npm/@digital-enabler/auth@2.0.3/app.js",
-    "@digital-enabler/demf-dme-event-handler": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dme-event-handler@2.1.5/app.js",
-    "@digital-enabler/sidebar": "https://cdn.jsdelivr.net/npm/@digital-enabler/sidebar@2.0.12/app.js",
-    "@digital-enabler/footer": "https://cdn.jsdelivr.net/npm/@digital-enabler/footer@2.0.3/app.js",
-    "@digital-enabler/demf-dtm-models-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dtm-models-list@0.0.9/app.js",
-    "@digital-enabler/demf-dtm-relations-editor": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dtm-relations-editor@0.0.10/app.js",
-    "@digital-enabler/demf-dtm-data-definition": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dtm-data-definition@0.0.10/app.js",
-    "@digital-enabler/demf-dtm-model-conversion": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dtm-model-conversion@0.0.6/app.js",
-    "@digital-enabler/demf-dtm-model-summary": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dtm-model-summary@0.0.8/app.js",
-    "@digital-enabler/demf-dtm-entities-list": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dtm-entities-list@0.0.3/app.js",
-    "@digital-enabler/demf-dtm-entity": "https://cdn.jsdelivr.net/npm/@digital-enabler/demf-dtm-entity@0.0.3/app.js",
-    "@digital-enabler/dtm-gui": "https://dtmui.avant.digital-enabler.eng.it/demf-dtm-gui.js"
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.33/dist/vue.global.min.js",
+    "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.6/dist/vue-router.global.min.js",
+    "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",
+    "demf-auth": "https://cdn.jsdelivr.net/npm/demf-auth@3.1.2/mf-app.js",
+    "demf-event-handler": "https://cdn.jsdelivr.net/npm/demf-event-handler@3.1.1/mf-app.js",
+    "demf-sidebar": "https://cdn.jsdelivr.net/npm/demf-sidebar@3.1.1/mf-app.js",
+    "demf-footer": "https://cdn.jsdelivr.net/npm/demf-footer@3.1.2/mf-app.js",
+    "demf-dtm-models-list": "https://cdn.jsdelivr.net/npm/demf-dtm-models-list@3.0.0/mf-app.js",
+    "demf-dtm-editor-definition": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-definition@3.0.0/mf-app.js",
+    "demf-dtm-editor-data-binding": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-data-binding@3.0.0/mf-app.js",
+    "demf-dtm-editor-conversion": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-conversion@3.0.0/mf-app.js",
+    "demf-dtm-editor-summary": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-summary@3.0.0/mf-app.js",
+    "demf-dtm-entities-list": "https://cdn.jsdelivr.net/npm/demf-dtm-entities-list@3.0.0/mf-app.js",
+    "demf-dtm-entity": "https://cdn.jsdelivr.net/npm/demf-dtm-entity@3.0.0/mf-app.js",
+    "demf-gui-root": "https://dtmui.avant.digital-enabler.eng.it/demf-dtm-gui.js"
   }
 }

--- a/mf-avant/dtm/dtm-models-list-config.json
+++ b/mf-avant/dtm/dtm-models-list-config.json
@@ -1,6 +1,6 @@
 {
-  "mf": "Digital Twin Models List",
+  "name": "DTM Models List",
+  "mf": "demf-dtm-models-list",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
-  "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
-  "apiAssetsUrl": "https://f87d8c7c-3048-465e-a9be-8131e2a875d8.mock.pstmn.io/api/v1"
+  "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-avant/dtm/dtm-sidebar-config.json
+++ b/mf-avant/dtm/dtm-sidebar-config.json
@@ -1,5 +1,6 @@
 {
-  "mf": "Sidebar",
+  "name": "Sidebar",
+  "mf": "demf-sidebar",
   "api": "https://pem-api.avant.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "jsonTools": "https://raw.githubusercontent.com/digital-enabler/UI-Configs/main/mf-dev/common/services.json",
@@ -7,7 +8,7 @@
     {
       "title": "labels.models",
       "icon": "mdi-graph-outline",
-      "link": "/dts"
+      "link": "/models"
     },
     {
       "title": "labels.entities",
@@ -18,9 +19,6 @@
   "favorites": {
     "enabled": false,
     "uri": ""
-  },
-  "keycloak": {
-    "enabled": true
   },
   "logo": "/dtm/DigitalTwinModeller.svg",
   "miniLogo": "/de-mini.svg",

--- a/mf-mediren/dtm/dtm-import-map.json
+++ b/mf-mediren/dtm/dtm-import-map.json
@@ -12,7 +12,7 @@
     "demf-dtm-editor-definition": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-definition@3.0.0/mf-app.js",
     "demf-dtm-editor-data-binding": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-data-binding@3.0.0/mf-app.js",
     "demf-dtm-editor-conversion": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-conversion@3.0.0/mf-app.js",
-    "demf-dtm-editor-summary": "https://cdn.jsdelivr.net/npm/demf-dtm-model-summary@3.0.0/mf-app.js",
+    "demf-dtm-editor-summary": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-summary@3.0.0/mf-app.js",
     "demf-dtm-entities-list": "https://cdn.jsdelivr.net/npm/demf-dtm-entities-list@3.0.0/mf-app.js",
     "demf-dtm-entity": "https://cdn.jsdelivr.net/npm/demf-dtm-entity@3.0.0/mf-app.js",
     "demf-gui-root": "https://dtm-mediren.eng.it/demf-dtm-gui.js"

--- a/temp/mf-avant/dtm/dtm-import-map.json
+++ b/temp/mf-avant/dtm/dtm-import-map.json
@@ -12,7 +12,7 @@
     "demf-dtm-editor-definition": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-definition@3.0.0/mf-app.js",
     "demf-dtm-editor-data-binding": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-data-binding@3.0.0/mf-app.js",
     "demf-dtm-editor-conversion": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-conversion@3.0.0/mf-app.js",
-    "demf-dtm-editor-summary": "https://cdn.jsdelivr.net/npm/demf-dtm-model-summary@3.0.0/mf-app.js",
+    "demf-dtm-editor-summary": "https://cdn.jsdelivr.net/npm/demf-dtm-editor-summary@3.0.0/mf-app.js",
     "demf-dtm-entities-list": "https://cdn.jsdelivr.net/npm/demf-dtm-entities-list@3.0.0/mf-app.js",
     "demf-dtm-entity": "https://cdn.jsdelivr.net/npm/demf-dtm-entity@3.0.0/mf-app.js",
     "demf-gui-root": "https://dtmui.avant.digital-enabler.eng.it/demf-dtm-gui.js"


### PR DESCRIPTION
Rename and standardize DTM configuration files and keys, add explicit name/mf fields and common api/storageImgs entries, and update sidebar route. Replace legacy digitalTwin* keys with dtm* keys in mf-avant/config.json and rename several dtm-* config files to dtm-editor-* variants. Update import maps to point to new demf package names and bumped versions (including demf-auth/event-handler/sidebar/footer and demf-dtm-* packages) and align equivalent entries in mf-mediren and temp imports. These changes align configs with the new demf microfrontend naming/versioning and unified API/storage settings.