### PR TITLE
[FIX] Use ESM single-spa in import maps

### DIFF
--- a/mf-avant/dd/dd-import-map.json
+++ b/mf-avant/dd/dd-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.32/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.4/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",

--- a/mf-avant/dme/dme-import-map.json
+++ b/mf-avant/dme/dme-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.22/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@4.6.3/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.10.4/dist/vuetify.min.js",

--- a/mf-avant/dtm/dtm-import-map.json
+++ b/mf-avant/dtm/dtm-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.33/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.6/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",

--- a/mf-avant/kpim/kpim-import-map.json
+++ b/mf-avant/kpim/kpim-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.22/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@4.6.3/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.10.7/dist/vuetify.min.js",

--- a/mf-mediren/dme/dme-import-map.json
+++ b/mf-mediren/dme/dme-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.22/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@4.6.3/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.10.4/dist/vuetify.min.js",

--- a/mf-mediren/dtm/dtm-import-map.json
+++ b/mf-mediren/dtm/dtm-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.33/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.6/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",

--- a/mf-mediren/kpim/kpim-import-map.json
+++ b/mf-mediren/kpim/kpim-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.22/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@4.6.3/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.10.7/dist/vuetify.min.js",

--- a/mf-mediren/rm/rm-import-map.json
+++ b/mf-mediren/rm/rm-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.22/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@4.6.3/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.10.4/dist/vuetify.min.js",

--- a/mf-regions4climate/dd/dd-import-map.json
+++ b/mf-regions4climate/dd/dd-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.32/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.4/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",

--- a/mf-regions4climate/dme/dme-import-map.json
+++ b/mf-regions4climate/dme/dme-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.22/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@4.6.3/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.10.4/dist/vuetify.min.js",

--- a/temp/mf-avant/dd/dd-import-map.json
+++ b/temp/mf-avant/dd/dd-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.22/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@4.6.3/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.4/dist/vuetify.min.js",

--- a/temp/mf-avant/dtm/dtm-import-map.json
+++ b/temp/mf-avant/dtm/dtm-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.33/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.6/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",

--- a/temp/mf-avant/kpim/kpim-import-map.json
+++ b/temp/mf-avant/kpim/kpim-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.33/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.6/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",

--- a/temp/mf-avant/rm/rm-import-map.json
+++ b/temp/mf-avant/rm/rm-import-map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/system/single-spa.min.js",
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
     "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.33/dist/vue.global.min.js",
     "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.6/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",


### PR DESCRIPTION
Switch single-spa imports from the System build to the ESM build (replace /lib/es2015/system/... with /lib/es2015/esm/...) in multiple import-map.json files across mf-avant, mf-mediren, mf-regions4climate and temp/mf-avant so the ES module variant of single-spa@6.0.3 is loaded.