### PR TITLE
[BUILD] Add MF Citrace DME and common config files

### DIFF
--- a/temp/mf-citrace/common/common-footer-config.json
+++ b/temp/mf-citrace/common/common-footer-config.json
@@ -1,0 +1,6 @@
+{
+    "name": "Footer",
+    "mf": "demf-footer",
+    "api": "",
+    "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
+}

--- a/temp/mf-citrace/common/services.json
+++ b/temp/mf-citrace/common/services.json
@@ -1,0 +1,92 @@
+[
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"Dashboard Manager",
+      "link":"",
+      "prefix":"dashboards.",
+      "path":"/",
+      "active":false,
+      "category":"data_visualization"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"Database Manager",
+      "link":"",
+      "prefix":"database.",
+      "path":"",
+      "active":true,
+      "category":"data_processing"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"Data Mashup",
+      "link":"",
+      "prefix":"mashups.",
+      "path":"",
+      "active":true,
+      "category":"data_processing"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"Dataflow",
+      "link":"",
+      "prefix":"airflow.",
+      "path":"",
+      "active":true,
+      "category":"data_management"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"Identity Manager",
+      "link":"",
+      "prefix":"idm.",
+      "path":"/auth/realms/[tenant]/account",
+      "active":true,
+      "category":"data_management"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"Storage",
+      "link":"",
+      "prefix":"storage-console.",
+      "path":"",
+      "active":true,
+      "category":"data_management"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"Device Manager",
+      "link":"",
+      "prefix":"devices.",
+      "path":"",
+      "active":true,
+      "category":"internet_things"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"ClouDev",
+      "link":"",
+      "prefix":"cloudev.",
+      "path":"",
+      "active":true,
+      "category":"tools_developers"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"AI Studio",
+      "link":"",
+      "prefix":".",
+      "path":"",
+      "active":false,
+      "category":"tools_developers"
+   },
+   {
+      "img":"//demo.digital-enabler.eng.it/suite/static/imgs/icons/icon_",
+      "name":"APIs",
+      "link":"",
+      "prefix":"api.",
+      "path":"",
+      "active":true,
+      "category":"tools_developers"
+   }
+]

--- a/temp/mf-citrace/dme/dme-auth-config.json
+++ b/temp/mf-citrace/dme/dme-auth-config.json
@@ -1,0 +1,10 @@
+{
+   "name": "Auth",
+   "mf": "demf-auth",
+   "api": "https://dme-api.digital-enabler.eng.it/api",
+   "keycloak": {
+      "url": "https://localhost:8787/auth",
+      "clientId": "dme-v2-app",
+      "enabled": false
+   }
+}

--- a/temp/mf-citrace/dme/dme-custom-operator-details-config.json
+++ b/temp/mf-citrace/dme/dme-custom-operator-details-config.json
@@ -1,0 +1,6 @@
+{
+  "name": "Custom Operator Details",
+  "mf": "demf-custom-operator-details",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+  "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
+}

--- a/temp/mf-citrace/dme/dme-custom-operators-config.json
+++ b/temp/mf-citrace/dme/dme-custom-operators-config.json
@@ -1,0 +1,6 @@
+{
+  "name": "Custom Operators",
+  "mf": "demf-custom-operators",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+  "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
+}

--- a/temp/mf-citrace/dme/dme-data-discovery-config.json
+++ b/temp/mf-citrace/dme/dme-data-discovery-config.json
@@ -1,0 +1,16 @@
+{
+  "name": "Data Discovery",
+  "mf": "demf-data-discovery",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+  "standaloneMode": false,
+  "fileFormats": {
+    "CSV": { "icon": "mdi-file-delimited", "color": "green" },
+    "JSON": { "icon": "mdi-code-json", "color": "blue" },
+    "XML": { "icon": "mdi-file-code", "color": "deep-orange" },
+    "PDF": { "icon": "mdi-file-pdf-box", "color": "red" },
+    "XLSX": { "icon": "mdi-file-excel", "color": "teal" },
+    "XLS": { "icon": "mdi-file-excel", "color": "teal" },
+    "ZIP": { "icon": "mdi-folder-zip", "color": "amber" }
+  },
+  "searchTimeout": 120000
+}

--- a/temp/mf-citrace/dme/dme-datasource-details-config.json
+++ b/temp/mf-citrace/dme/dme-datasource-details-config.json
@@ -1,0 +1,6 @@
+{
+   "name": "Datasource Details",
+   "mf": "demf-datasource-details",
+   "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
+}

--- a/temp/mf-citrace/dme/dme-datasources-list-config.json
+++ b/temp/mf-citrace/dme/dme-datasources-list-config.json
@@ -1,0 +1,6 @@
+{
+    "name": "Datasources List",
+    "mf": "demf-datasources-list",
+    "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+    "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
+}

--- a/temp/mf-citrace/dme/dme-event-handler-config.json
+++ b/temp/mf-citrace/dme/dme-event-handler-config.json
@@ -1,0 +1,5 @@
+{
+    "name": "Event Handler",
+    "mf": "demf-event-handler",
+    "api": "https://dme-api.digital-enabler.eng.it/api/v3"
+}

--- a/temp/mf-citrace/dme/dme-flow-editor-config.json
+++ b/temp/mf-citrace/dme/dme-flow-editor-config.json
@@ -1,0 +1,6 @@
+{
+  "name": "Flow Editor",
+  "mf": "demf-flow-editor",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+  "triggerProxyUrlLayout": "[protocol_current_url]//dme-proxy.[Tenant][domain_current_url]/mashups/[id_flow]"
+}

--- a/temp/mf-citrace/dme/dme-flows-list-config.json
+++ b/temp/mf-citrace/dme/dme-flows-list-config.json
@@ -1,0 +1,6 @@
+{
+  "name": "Flows List",
+  "mf": "demf-flows-list",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+  "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
+}

--- a/temp/mf-citrace/dme/dme-import-map.json
+++ b/temp/mf-citrace/dme/dme-import-map.json
@@ -1,0 +1,23 @@
+{
+  "imports": {
+    "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
+    "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.33/dist/vue.global.min.js",
+    "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.6/dist/vue-router.global.min.js",
+    "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",
+    "demf-auth": "https://cdn.jsdelivr.net/npm/demf-auth@3.1.2/mf-app.js",
+    "demf-event-handler": "https://cdn.jsdelivr.net/npm/demf-event-handler@3.1.1/mf-app.js",
+    "demf-sidebar": "https://cdn.jsdelivr.net/npm/demf-sidebar@3.1.1/mf-app.js",
+    "demf-footer": "https://cdn.jsdelivr.net/npm/demf-footer@3.1.2/mf-app.js",
+    "demf-mashups-list": "https://cdn.jsdelivr.net/npm/demf-mashups-list@4.0.0/mf-app.js",
+    "demf-mashups-editor": "https://cdn.jsdelivr.net/npm/demf-mashups-editor@4.0.0/mf-app.js",
+    "demf-mashups-editor-appbar": "https://cdn.jsdelivr.net/npm/demf-mashups-editor-appbar@4.0.0/mf-app.js",
+    "demf-datasources-list": "https://cdn.jsdelivr.net/npm/demf-datasources-list@4.0.0/mf-app.js",
+    "demf-datasource-details": "https://cdn.jsdelivr.net/npm/demf-datasource-details@4.0.0/mf-app.js",
+    "demf-flows-list": "https://cdn.jsdelivr.net/npm/demf-flows-list@4.0.0/mf-app.js",
+    "demf-flow-editor": "https://cdn.jsdelivr.net/npm/demf-flow-editor@4.0.0/mf-app.js",
+    "demf-custom-operators": "https://cdn.jsdelivr.net/npm/demf-custom-operators@4.0.0/mf-app.js",
+    "demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/demf-custom-operator-details@4.0.0/mf-app.js",
+    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.1/mf-app.js",
+    "demf-gui-root": "https://mashups.citrace.digital-enabler.eng.it/gui-root.js"
+  }
+}

--- a/temp/mf-citrace/dme/dme-mashups-editor-appbar-config.json
+++ b/temp/mf-citrace/dme/dme-mashups-editor-appbar-config.json
@@ -1,0 +1,5 @@
+{
+  "name": "Mashup Editor Appbar",
+  "mf": "demf-mashups-editor-appbar",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3"
+}

--- a/temp/mf-citrace/dme/dme-mashups-editor-config.json
+++ b/temp/mf-citrace/dme/dme-mashups-editor-config.json
@@ -1,0 +1,12 @@
+{
+  "name": "Mashup Editor",
+  "mf": "demf-mashups-editor",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+  "apiDraw": "https://dme-api.digital-enabler.eng.it/v3",
+  "importFileType": {
+    "csv": ".csv",
+    "excel": ".xls,.xlsx",
+    "json": ".json",
+    "text": ".txt"
+  }
+}

--- a/temp/mf-citrace/dme/dme-mashups-list-config.json
+++ b/temp/mf-citrace/dme/dme-mashups-list-config.json
@@ -1,0 +1,6 @@
+{
+  "name": "Mashups List",
+  "mf": "demf-mashups-list",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+  "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
+}

--- a/temp/mf-citrace/dme/dme-share-form-config.json
+++ b/temp/mf-citrace/dme/dme-share-form-config.json
@@ -1,0 +1,5 @@
+{
+  "name": "Share Form",
+  "mf": "demf-share-form",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3"
+}

--- a/temp/mf-citrace/dme/dme-sidebar-config.json
+++ b/temp/mf-citrace/dme/dme-sidebar-config.json
@@ -1,0 +1,39 @@
+{
+  "name": "Sidebar",
+  "mf": "demf-sidebar",
+  "api": "https://dme-api.digital-enabler.eng.it/api/v3",
+  "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
+  "jsonTools": "https://raw.githubusercontent.com/robraccu/storage/main/UI-Configs/mf-dev/common/services.json",
+  "links": [
+    {
+      "title": "labels.mashups",
+      "icon": "mdi-file-tree",
+      "link": "/mashups"
+    },
+    {
+      "title": "labels.datasources",
+      "icon": "mdi-database",
+      "link": "/datasources"
+    },
+    {
+      "title": "labels.flows",
+      "icon": "mdi-transit-connection-horizontal",
+      "link": "/flows"
+    },
+    {
+      "title": "labels.custom-operators",
+      "icon": "mdi-puzzle",
+      "link": "/custom-operators"
+    }
+  ],
+  "favorites": {
+    "enabled": false,
+    "uri": ""
+  },
+  "keycloak": {
+    "enabled": false
+  },
+  "logo": "/DataMashupEditor.svg",
+  "miniLogo": "/de-mini.svg",
+  "showServicesMenu": false
+}


### PR DESCRIPTION
Add multiple configuration JSON files for the mf-citrace deployment. Includes common configs (services.json, common-footer-config.json), DME micro-frontend configs (auth, sidebar, footer, mashups editor/list/appbar, flows list, flow editor, datasources list/details, data discovery, event handler, share form, custom operators/details) and an import map for CDN-hosted MF bundles. Sets DME API endpoints, storage image base, file format icons, sidebar links, keycloak defaults, and runtime import URLs to enable micro-frontend integration and routing.