### PR TITLE
Update KPIM middleware API host

### DIFF
--- a/mf-regions4climate/kpim/kpim-auth-config.json
+++ b/mf-regions4climate/kpim/kpim-auth-config.json
@@ -1,7 +1,7 @@
 {
    "name":"Auth",
    "mf": "demf-auth",
-   "api":"https://kpim-middleware-api.avant.digital-enabler.eng.it/api/v1",
+   "api":"https://kpim-middleware-api.regions4climate.digital-enabler.eng.it/api/v1",
    "keycloak":{
       "url":"https://idm.digital-enabler.eng.it/auth",
       "clientId":"kpi-manager-app",

--- a/mf-regions4climate/kpim/kpim-compare-config.json
+++ b/mf-regions4climate/kpim/kpim-compare-config.json
@@ -1,5 +1,5 @@
 {
   "name": "KPIM Compare",
   "mf": "demf-kpim-compare",
-  "api": "https://kpim-middleware-api.avant.digital-enabler.eng.it/api/v1"
+  "api": "https://kpim-middleware-api.regions4climate.digital-enabler.eng.it/api/v1"
 }

--- a/mf-regions4climate/kpim/kpim-editor-config.json
+++ b/mf-regions4climate/kpim/kpim-editor-config.json
@@ -1,7 +1,7 @@
 {
   "name": "KPIM Editor",
   "mf": "demf-kpim-editor",
-  "api": "https://kpim-middleware-api.avant.digital-enabler.eng.it/api/v1",
+  "api": "https://kpim-middleware-api.regions4climate.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "unitSymbols": {
     "METER":"m",

--- a/mf-regions4climate/kpim/kpim-event-handler-config.json
+++ b/mf-regions4climate/kpim/kpim-event-handler-config.json
@@ -1,5 +1,5 @@
 {
     "name": "Event Handler",
     "mf": "demf-event-handler",
-    "api": "https://kpim-middleware-api.avant.digital-enabler.eng.it/api/v1"
+    "api": "https://kpim-middleware-api.regions4climate.digital-enabler.eng.it/api/v1"
 }

--- a/mf-regions4climate/kpim/kpim-kpis-list-config.json
+++ b/mf-regions4climate/kpim/kpim-kpis-list-config.json
@@ -1,6 +1,6 @@
 {
   "name": "KPIs List",
   "mf": "demf-kpis-list",
-  "api": "https://kpim-middleware-api.avant.digital-enabler.eng.it/api/v1",
+  "api": "https://kpim-middleware-api.regions4climate.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-regions4climate/kpim/kpim-measure-config.json
+++ b/mf-regions4climate/kpim/kpim-measure-config.json
@@ -1,6 +1,6 @@
 {
   "name": "KPIM Measure",
   "mf": "demf-kpim-measure",
-  "api": "https://kpim-middleware-api.avant.digital-enabler.eng.it/api/v1",
+  "api": "https://kpim-middleware-api.regions4climate.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-regions4climate/kpim/kpim-measures-list-config.json
+++ b/mf-regions4climate/kpim/kpim-measures-list-config.json
@@ -1,6 +1,6 @@
 {
   "name": "Measures List",
   "mf": "demf-kpim-measures-list",
-  "api": "https://kpim-middleware-api.avant.digital-enabler.eng.it/api/v1",
+  "api": "https://kpim-middleware-api.regions4climate.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs"
 }

--- a/mf-regions4climate/kpim/kpim-sidebar-config.json
+++ b/mf-regions4climate/kpim/kpim-sidebar-config.json
@@ -1,7 +1,7 @@
 {
   "name": "Sidebar",
   "mf": "demf-sidebar",
-  "api": "https://kpim-middleware-api.avant.digital-enabler.eng.it/api/v1",
+  "api": "https://kpim-middleware-api.regions4climate.digital-enabler.eng.it/api/v1",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "jsonTools": "https://raw.githubusercontent.com/digital-enabler/UI-Configs/main/mf-avant/common/services.json",
   "links": [


### PR DESCRIPTION
Replace kpim-middleware-api.avant.digital-enabler.eng.it with kpim-middleware-api.regions4climate.digital-enabler.eng.it in KPIM config files to point services to the regions4climate middleware. Updated files: mf-regions4climate/kpim/kpim-auth-config.json, kpim-compare-config.json, kpim-editor-config.json, kpim-event-handler-config.json, kpim-kpis-list-config.json, kpim-measure-config.json, kpim-measures-list-config.json, kpim-sidebar-config.json.