### PR TITLE
Update discovery API endpoints and DD version

### DIFF
--- a/mf-avant/dd/dd-auth-config.json
+++ b/mf-avant/dd/dd-auth-config.json
@@ -1,10 +1,5 @@
 {
    "name": "Auth",
    "mf": "demf-auth",
-   "api": "https://dme-api.avant.digital-enabler.eng.it/api",
-   "keycloak": {
-      "url": "https://localhost:8787/auth",
-      "clientId": "dme-v2-app",
-      "enabled": false
-   }
+   "api": "https://discovery-api.avant.digital-enabler.eng.it/api"
 }

--- a/mf-avant/dd/dd-event-handler-config.json
+++ b/mf-avant/dd/dd-event-handler-config.json
@@ -1,5 +1,5 @@
 {
     "name": "Event Handler",
     "mf": "demf-event-handler",
-    "api": "https://dme-api.avant.digital-enabler.eng.it/api"
+    "api": "https://discovery-api.avant.digital-enabler.eng.it/api"
 }

--- a/mf-avant/dd/dd-import-map.json
+++ b/mf-avant/dd/dd-import-map.json
@@ -8,7 +8,7 @@
     "demf-event-handler": "https://cdn.jsdelivr.net/npm/demf-event-handler@3.1.2/mf-app.js",
     "demf-sidebar": "https://cdn.jsdelivr.net/npm/demf-sidebar@3.1.2/mf-app.js",
     "demf-footer": "https://cdn.jsdelivr.net/npm/demf-footer@3.1.3/mf-app.js",
-    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.2/mf-app.js",
+    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.3/mf-app.js",
     "demf-gui-root": "https://discovery.avant.digital-enabler.eng.it/gui-root.js"
   }
 }

--- a/mf-avant/dd/dd-sidebar-config.json
+++ b/mf-avant/dd/dd-sidebar-config.json
@@ -1,7 +1,7 @@
 {
   "name": "Sidebar",
   "mf": "demf-sidebar",
-  "api": "https://dme-api.avant.digital-enabler.eng.it/api",
+  "api": "https://discovery-api.avant.digital-enabler.eng.it/api",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "jsonTools": "https://raw.githubusercontent.com/digital-enabler/UI-Configs/main/mf-avant/common/services.json",
   "links": [

--- a/mf-avant/dd/dd-sidebar-config.json
+++ b/mf-avant/dd/dd-sidebar-config.json
@@ -14,7 +14,7 @@
   "favorites": {
     "enabled": true
   },
-  "logo": "/rm/DataDiscovery.svg",
-  "miniLogo": "/de-mini.svg",
+  "logo": "/dd/DataDiscovery.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-avant/dme/dme-import-map.json
+++ b/mf-avant/dme/dme-import-map.json
@@ -17,7 +17,7 @@
     "demf-flow-editor": "https://cdn.jsdelivr.net/npm/demf-flow-editor@4.2.2/mf-app.js",
     "demf-custom-operators": "https://cdn.jsdelivr.net/npm/demf-custom-operators@4.0.2/mf-app.js",
     "demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/demf-custom-operator-details@4.0.2/mf-app.js",
-    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.2/mf-app.js",
+    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.3/mf-app.js",
     "demf-gui-root": "https://mashups.avant.digital-enabler.eng.it/gui-root.js"
   }
 }

--- a/mf-avant/dme/dme-sidebar-config.json
+++ b/mf-avant/dme/dme-sidebar-config.json
@@ -38,7 +38,7 @@
   "keycloak": {
     "enabled": false
   },
-  "logo": "/DataMashupEditor.svg",
-  "miniLogo": "/de-mini.svg",
+  "logo": "/dme/DataMashupEditor.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-avant/dtm/dtm-sidebar-config.json
+++ b/mf-avant/dtm/dtm-sidebar-config.json
@@ -21,6 +21,6 @@
     "uri": ""
   },
   "logo": "/dtm/DigitalTwinModeller.svg",
-  "miniLogo": "/de-mini.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-avant/kpim/kpim-sidebar-config.json
+++ b/mf-avant/kpim/kpim-sidebar-config.json
@@ -24,6 +24,6 @@
     "enabled": false
   },
   "logo": "/kpim/KpiManager.svg",
-  "miniLogo": "/de-mini.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-avant/rm/rm-sidebar-config.json
+++ b/mf-avant/rm/rm-sidebar-config.json
@@ -16,6 +16,6 @@
       "uri": ""
    },
    "logo": "/rm/RuleManager.svg",
-   "miniLogo": "/de-mini.svg",
+   "miniLogo": "/commons/de-mini.svg",
    "showServicesMenu": false
 }

--- a/mf-citrace/dme/dme-import-map.json
+++ b/mf-citrace/dme/dme-import-map.json
@@ -17,7 +17,7 @@
     "demf-flow-editor": "https://cdn.jsdelivr.net/npm/demf-flow-editor@4.2.2/mf-app.js",
     "demf-custom-operators": "https://cdn.jsdelivr.net/npm/demf-custom-operators@4.0.2/mf-app.js",
     "demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/demf-custom-operator-details@4.0.2/mf-app.js",
-    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.2/mf-app.js",
+    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.3/mf-app.js",
     "demf-gui-root": "https://mashups.citrace.digital-enabler.eng.it/gui-root.js"
   }
 }

--- a/mf-citrace/dme/dme-sidebar-config.json
+++ b/mf-citrace/dme/dme-sidebar-config.json
@@ -33,7 +33,7 @@
   "keycloak": {
     "enabled": false
   },
-  "logo": "/DataMashupEditor.svg",
-  "miniLogo": "/de-mini.svg",
+  "logo": "/dme/DataMashupEditor.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-evita/dme/dme-sidebar-config.json
+++ b/mf-evita/dme/dme-sidebar-config.json
@@ -27,7 +27,7 @@
    "keycloak": {
       "enabled": false
    },
-   "logo": "/DataMashupEditor.svg",
-   "miniLogo": "/de-mini.svg",
+   "logo": "/dme/DataMashupEditor.svg",
+   "miniLogo": "/commons/de-mini.svg",
    "showServicesMenu": false
 }

--- a/mf-mediren/dme/dme-import-map.json
+++ b/mf-mediren/dme/dme-import-map.json
@@ -17,7 +17,7 @@
     "demf-flow-editor": "https://cdn.jsdelivr.net/npm/demf-flow-editor@4.2.2/mf-app.js",
     "demf-custom-operators": "https://cdn.jsdelivr.net/npm/demf-custom-operators@4.0.2/mf-app.js",
     "demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/demf-custom-operator-details@4.0.2/mf-app.js",
-    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.2/mf-app.js",
+    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.3/mf-app.js",
     "demf-gui-root": "https://mashups-mediren.eng.it/gui-root.js"
   }
 }

--- a/mf-mediren/dme/dme-sidebar-config.json
+++ b/mf-mediren/dme/dme-sidebar-config.json
@@ -38,7 +38,7 @@
   "keycloak": {
     "enabled": false
   },
-  "logo": "/DataMashupEditor.svg",
-  "miniLogo": "/de-mini.svg",
+  "logo": "/dme/DataMashupEditor.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-mediren/dtm/dtm-sidebar-config.json
+++ b/mf-mediren/dtm/dtm-sidebar-config.json
@@ -21,6 +21,6 @@
     "uri": ""
   },
   "logo": "/dtm/DigitalTwinModeller.svg",
-  "miniLogo": "/de-mini.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-mediren/kpim/kpim-sidebar-config.json
+++ b/mf-mediren/kpim/kpim-sidebar-config.json
@@ -24,6 +24,6 @@
     "enabled": false
   },
   "logo": "/kpim/KpiManager.svg",
-  "miniLogo": "/de-mini.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-mediren/rm/rm-sidebar-config.json
+++ b/mf-mediren/rm/rm-sidebar-config.json
@@ -19,6 +19,6 @@
     "enabled": true
   },
   "logo": "/rm/RuleManager.svg",
-  "miniLogo": "/de-mini.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-regions4climate/dd/dd-auth-config.json
+++ b/mf-regions4climate/dd/dd-auth-config.json
@@ -1,7 +1,7 @@
 {
    "name": "Auth",
    "mf": "demf-auth",
-   "api": "https://dme-api.digital-enabler.eng.it/api",
+   "api": "https://discovery-api.regions4climate.digital-enabler.eng.it/api",
    "keycloak": {
       "url": "https://localhost:8787/auth",
       "clientId": "dme-v2-app",

--- a/mf-regions4climate/dd/dd-event-handler-config.json
+++ b/mf-regions4climate/dd/dd-event-handler-config.json
@@ -1,5 +1,5 @@
 {
     "name": "Event Handler",
     "mf": "demf-event-handler",
-    "api": "https://dme-api.digital-enabler.eng.it/api"
+    "api": "https://discovery-api.regions4climate.digital-enabler.eng.it/api"
 }

--- a/mf-regions4climate/dd/dd-import-map.json
+++ b/mf-regions4climate/dd/dd-import-map.json
@@ -8,7 +8,7 @@
     "demf-event-handler": "https://cdn.jsdelivr.net/npm/demf-event-handler@3.1.1/mf-app.js",
     "demf-sidebar": "https://cdn.jsdelivr.net/npm/demf-sidebar@3.1.1/mf-app.js",
     "demf-footer": "https://cdn.jsdelivr.net/npm/demf-footer@3.1.2/mf-app.js",
-    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.1/mf-app.js",
+    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.3/mf-app.js",
     "demf-gui-root": "https://discovery.regions4climate.digital-enabler.eng.it/gui-root.js"
   }
 }

--- a/mf-regions4climate/dd/dd-import-map.json
+++ b/mf-regions4climate/dd/dd-import-map.json
@@ -1,13 +1,13 @@
 {
   "imports": {
     "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@6.0.3/lib/es2015/esm/single-spa.min.js",
-    "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.32/dist/vue.global.min.js",
-    "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.4/dist/vue-router.global.min.js",
+    "vue": "https://cdn.jsdelivr.net/npm/vue@3.5.33/dist/vue.global.min.js",
+    "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@5.0.6/dist/vue-router.global.min.js",
     "vuetify": "https://cdn.jsdelivr.net/npm/vuetify@3.12.5/dist/vuetify.min.js",
-    "demf-auth": "https://cdn.jsdelivr.net/npm/demf-auth@3.1.2/mf-app.js",
-    "demf-event-handler": "https://cdn.jsdelivr.net/npm/demf-event-handler@3.1.1/mf-app.js",
-    "demf-sidebar": "https://cdn.jsdelivr.net/npm/demf-sidebar@3.1.1/mf-app.js",
-    "demf-footer": "https://cdn.jsdelivr.net/npm/demf-footer@3.1.2/mf-app.js",
+    "demf-auth": "https://cdn.jsdelivr.net/npm/demf-auth@3.1.3/mf-app.js",
+    "demf-event-handler": "https://cdn.jsdelivr.net/npm/demf-event-handler@3.1.2/mf-app.js",
+    "demf-sidebar": "https://cdn.jsdelivr.net/npm/demf-sidebar@3.1.2/mf-app.js",
+    "demf-footer": "https://cdn.jsdelivr.net/npm/demf-footer@3.1.3/mf-app.js",
     "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.3/mf-app.js",
     "demf-gui-root": "https://discovery.regions4climate.digital-enabler.eng.it/gui-root.js"
   }

--- a/mf-regions4climate/dd/dd-sidebar-config.json
+++ b/mf-regions4climate/dd/dd-sidebar-config.json
@@ -1,7 +1,7 @@
 {
   "name": "Sidebar",
   "mf": "demf-sidebar",
-  "api": "https://dme-api.digital-enabler.eng.it/api",
+  "api": "https://discovery-api.regions4climate.digital-enabler.eng.it/api",
   "storageImgs": "https://storage.digital-enabler.eng.it/imgs",
   "jsonTools": "https://raw.githubusercontent.com/digital-enabler/UI-Configs/main/mf-regions4climate/common/services.json",
   "links": [

--- a/mf-regions4climate/dd/dd-sidebar-config.json
+++ b/mf-regions4climate/dd/dd-sidebar-config.json
@@ -14,7 +14,7 @@
   "favorites": {
     "enabled": true
   },
-  "logo": "/rm/DataDiscovery.svg",
-  "miniLogo": "/de-mini.svg",
+  "logo": "/dd/DataDiscovery.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-regions4climate/dme/dme-import-map.json
+++ b/mf-regions4climate/dme/dme-import-map.json
@@ -17,7 +17,7 @@
     "demf-flow-editor": "https://cdn.jsdelivr.net/npm/demf-flow-editor@4.2.2/mf-app.js",
     "demf-custom-operators": "https://cdn.jsdelivr.net/npm/demf-custom-operators@4.0.2/mf-app.js",
     "demf-custom-operator-details": "https://cdn.jsdelivr.net/npm/demf-custom-operator-details@4.0.2/mf-app.js",
-    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.2/mf-app.js",
+    "demf-data-discovery": "https://cdn.jsdelivr.net/npm/demf-data-discovery@3.1.3/mf-app.js",
     "demf-gui-root": "https://mashups.regions4climate.digital-enabler.eng.it/gui-root.js"
   }
 }

--- a/mf-regions4climate/dme/dme-sidebar-config.json
+++ b/mf-regions4climate/dme/dme-sidebar-config.json
@@ -33,7 +33,7 @@
   "keycloak": {
     "enabled": false
   },
-  "logo": "/DataMashupEditor.svg",
-  "miniLogo": "/de-mini.svg",
+  "logo": "/dme/DataMashupEditor.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }

--- a/mf-regions4climate/kpim/kpim-sidebar-config.json
+++ b/mf-regions4climate/kpim/kpim-sidebar-config.json
@@ -24,6 +24,6 @@
     "enabled": false
   },
   "logo": "/kpim/KpiManager.svg",
-  "miniLogo": "/de-mini.svg",
+  "miniLogo": "/commons/de-mini.svg",
   "showServicesMenu": false
 }


### PR DESCRIPTION
Switch Data Discovery-related API URLs from dme-api to discovery-api in Avant and Regions4Climate DD configs, including auth, sidebar, and event handler settings. Also bump `demf-data-discovery` to `3.1.3` across DD/DME import maps for Avant, Regions4Climate, Citrace, and Mediren, and remove the obsolete Keycloak block from Avant DD auth config.